### PR TITLE
DEV-4306: Bump version to 1.4.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@out-fund/segment-events",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@out-fund/segment-events",
-      "version": "1.4.8",
+      "version": "1.4.9",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^28.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@out-fund/segment-events",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "A simple library for track listeners & events for Segment.io",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
# Description

Bump version because I published and unpublished 1.4.8 and could no publish again
```
npm notice Publishing to https://registry.npmjs.org/
npm ERR! code E400
npm ERR! 400 Bad Request - PUT https://registry.npmjs.org/@out-fund%2fsegment-events - Cannot publish over previously published version "1.4.8".

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/angel/.npm/_logs/2024-01-17T15_13_18_729Z-debug-0.log
```
![Screenshot 2024-01-17 at 16 41 57](https://github.com/shiggydoodah/segment-events/assets/3584070/83f3d069-d1b2-45d6-b053-5d5f18741055)


# Notice
This version has been published already.

# Commands to publish
```
npm adduser
npm version 1.4.9
npm publish --access public
```

with NPM registry account details:

```
https://www.npmjs.com/~out-fund
tech@out.fund
Password: user reset link and get reset link in https://groups.google.com/a/out.fund/g/tech
```